### PR TITLE
Saving and showing confidence scores outputs as float for both ultralight and blazeface

### DIFF
--- a/mukh/face_detection/models/blazeface/blazeface_detector.py
+++ b/mukh/face_detection/models/blazeface/blazeface_detector.py
@@ -123,7 +123,11 @@ class BlazeFaceDetector(BaseFaceDetector):
             y2 = float(detection[2]) * orig_h  # ymax
 
             bbox = BoundingBox(
-                x1=int(x1), y1=int(y1), x2=int(x2), y2=int(y2), confidence=detection[16]
+                x1=int(x1),
+                y1=int(y1),
+                x2=int(x2),
+                y2=int(y2),
+                confidence=detection[16].item()
             )
 
             faces.append(FaceDetection(bbox=bbox))

--- a/mukh/face_detection/models/ultralight/ultralight_detector.py
+++ b/mukh/face_detection/models/ultralight/ultralight_detector.py
@@ -155,7 +155,7 @@ class UltralightDetector(BaseFaceDetector):
                 y1=int(box[1] * height_scale),
                 x2=int(box[2] * width_scale),
                 y2=int(box[3] * height_scale),
-                confidence=probs[i],
+                confidence=probs[i].item(),
             )
             # Ultralight doesn't provide landmarks, so we pass None
             faces.append(FaceDetection(bbox=bbox))


### PR DESCRIPTION
Made the following changes in the code as explained:
1 . in ```mukh\mukh\face_detection\models\ultralight\ultralight_detector.py```
      

            bbox = BoundingBox(

                x1=int(box[0] * width_scale),

                y1=int(box[1] * height_scale),

                x2=int(box[2] * width_scale),

                y2=int(box[3] * height_scale),

                confidence=probs[i].item(),
            )
  2.  in ```mukh\mukh\face_detection\models\blazeface\blazeface_detector.py```
            `   
 bbox = BoundingBox(

                x1=int(x1),

                y1=int(y1),

                x2=int(x2), 

                y2=int(y2),

                confidence=detection[16].item()
            )
`

@ishandutta0098 please check and confirm.